### PR TITLE
Fix the handling of placeholders in strict requirements

### DIFF
--- a/Routing/Generator/Rfc6570Generator.php
+++ b/Routing/Generator/Rfc6570Generator.php
@@ -53,7 +53,7 @@ class Rfc6570Generator extends UrlGenerator implements UrlGeneratorInterface, Co
             if ('variable' === $token[0]) {
                 if (!$optional || !array_key_exists($token[3], $defaults) || (string) $mergedParams[$token[3]] !== (string) $defaults[$token[3]]) {
                     // check requirement
-                    if (null !== $this->strictRequirements && !preg_match('#^'.$token[2].'$#', $mergedParams[$token[3]])) {
+                    if (null !== $this->strictRequirements && !$this->isPlaceHolder($mergedParams[$token[3]]) && !preg_match('#^'.$token[2].'$#', $mergedParams[$token[3]])) {
                         $message = sprintf('Parameter "%s" for route "%s" must match "%s" ("%s" given) to generate a corresponding URL.', $token[3], $name, $token[2], $mergedParams[$token[3]]);
                         if ($this->strictRequirements) {
                             throw new InvalidParameterException($message);
@@ -167,5 +167,9 @@ class Rfc6570Generator extends UrlGenerator implements UrlGeneratorInterface, Co
         }
 
         return $url;
+    }
+
+    private function isPlaceHolder($param) {
+        return (substr($param, 0, 1 ) == '{' && substr($param, -1 ) == '}');
     }
 }

--- a/Routing/Generator/Rfc6570Generator.php
+++ b/Routing/Generator/Rfc6570Generator.php
@@ -169,7 +169,10 @@ class Rfc6570Generator extends UrlGenerator implements UrlGeneratorInterface, Co
         return $url;
     }
 
-    private function isPlaceHolder($param) {
-        return (substr($param, 0, 1 ) == '{' && substr($param, -1 ) == '}');
+    private function isPlaceHolder($param)
+    {
+        $length = strlen($param);
+
+        return $length > 2 && '{' === $param[0] && '}' === $param[$length - 1];
     }
 }

--- a/Tests/Routing/Generator/Rfc6570GeneratorTest.php
+++ b/Tests/Routing/Generator/Rfc6570GeneratorTest.php
@@ -53,6 +53,25 @@ class Rfc6570GeneratorTest extends \PHPUnit_Framework_TestCase
         );
     }
 
+    public function testPlaceholderInStrictParameter()
+    {
+        $routes = new RouteCollection();
+
+        $routes->add('foo', new Route(
+            '/foo/{foo}/',
+            array(
+                'foo' => '123',
+            ),
+            array(
+                'foo' => '\d+',
+            )
+        ));
+
+        $generator = new Rfc6570Generator($routes, new RequestContext());
+
+        $this->assertEquals('/foo/{placeholder}/{?bar}', $generator->generate('foo', array('foo' => '{placeholder}', 'bar' => 'barbar')));
+    }
+
     /**
      * @expectedException \Symfony\Component\Routing\Exception\InvalidParameterException
      */


### PR DESCRIPTION
As I commented in #10, the tests added in this commit are not showing that #9 is not needed, because they are not covering the case of #9.

The first commit in this PR is adding a failing tests reproducing the issue. Next ones are cherry-picking #9 to reapply it to fix the issue.