### PR TITLE
Symfony 3.0 compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,14 +17,6 @@ matrix:
   include:
     - php: 5.3
       env: dependencies=lowest
-    - php: 5.4
-      env: dependencies=lowest
-    - php: 5.5
-      env: dependencies=lowest
-    - php: 5.6
-      env: dependencies=lowest
-    - php: hhvm
-      env: dependencies=lowest
 
 install:
   - if [ -z "$dependencies" ]; then travis_retry composer install; fi;

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,8 +13,23 @@ php:
   - 5.6
   - hhvm
 
+matrix:
+  include:
+    - php: 5.3
+      env: dependencies=lowest
+    - php: 5.4
+      env: dependencies=lowest
+    - php: 5.5
+      env: dependencies=lowest
+    - php: 5.6
+      env: dependencies=lowest
+    - php: hhvm
+      env: dependencies=lowest
+
 install:
-  - composer install
+  - if [ -z "$dependencies" ]; then travis_retry composer install; fi;
+  - if [ "$dependencies" = "lowest" ]; then travis_retry composer update --prefer-lowest; fi;
+  - composer show -i
 
 script:
   - phpunit --coverage-text

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     ],
     "require": {
         "php": ">=5.3.0",
-        "symfony/routing": "~2.5"
+        "symfony/routing": "~2.5|~3.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
* Support both ~2.5 and ~3.0 for symfony/routing in composer.json
* Adjust travis config to run tests with lowest dependency versions