### PR TITLE
Adding Symfony4 support & fix phpunit compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,21 +7,26 @@ cache:
         - $HOME/.composer/cache
 
 php:
-  - 5.3
   - 5.4
   - 5.5
   - 5.6
-  - hhvm
+  - 7.0
+  - 7.1
 
 matrix:
   include:
-    - php: 5.3
-      env: dependencies=lowest
+    - php: 5.6
+      env: SYMFONY_VERSION=^3.0 DEPENDENCIES=dev COMPOSER_FLAGS="--prefer-stable"
+    - php: 7.1
+      env: dependencies=beta
 
-install:
-  - if [ -z "$dependencies" ]; then travis_retry composer install; fi;
-  - if [ "$dependencies" = "lowest" ]; then travis_retry composer update --prefer-lowest; fi;
-  - composer show -i
+before_install:
+  - composer self-update
+  - if [ "$SYMFONY_VERSION" != "" ]; then composer require --dev --no-update symfony/framework-bundle=$SYMFONY_VERSION; fi
+  - if [ "$DEPENDENCIES" = "dev" ]; then perl -pi -e 's/^}$/,"minimum-stability":"dev"}/' composer.json; fi;
+  - if [ "$DEPENDENCIES" = "beta" ]; then composer config minimum-stability beta; fi;
+
+install: composer update $COMPOSER_FLAGS
 
 script:
   - phpunit --coverage-text

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,30 +6,31 @@ cache:
     directories:
         - $HOME/.composer/cache
 
-php:
-  - 5.4
-  - 5.5
-  - 5.6
-  - 7.0
-  - 7.1
-
 matrix:
   include:
+    - php: 5.3
+      dist: precise
+    - php: 5.4
+      env: COMPOSER_FLAGS="--prefer-lowest"
+    - php: 5.5
     - php: 5.6
-      env: SYMFONY_VERSION=^3.0 DEPENDENCIES=dev COMPOSER_FLAGS="--prefer-stable"
+      env: SYMFONY_LTS=v3 DEPENDENCIES=dev COMPOSER_FLAGS="--prefer-stable"
+    - php: 7.0
+      env: SYMFONY_LTS=v2
     - php: 7.1
-      env: dependencies=beta
+    - php: 7.2
+      env: DEPENDENCIES=dev
+    - php: hhvm
+      env: SYMFONY_LTS=v3
 
 before_install:
-  - composer self-update
-  - if [ "$SYMFONY_VERSION" != "" ]; then composer require --dev --no-update symfony/framework-bundle=$SYMFONY_VERSION; fi
-  - if [ "$DEPENDENCIES" = "dev" ]; then perl -pi -e 's/^}$/,"minimum-stability":"dev"}/' composer.json; fi;
-  - if [ "$DEPENDENCIES" = "beta" ]; then composer config minimum-stability beta; fi;
+  - if [ "$SYMFONY_LTS" != "" ]; then composer require --dev --no-update symfony/lts=$SYMFONY_LTS; fi
+  - if [ "$DEPENDENCIES" = "dev" ]; then composer config minimum-stability dev; fi;
 
-install: composer update $COMPOSER_FLAGS
+install: travis_retry composer update $COMPOSER_FLAGS
 
 script:
-  - phpunit --coverage-text
+  - php vendor/bin/phpunit --coverage-text
 
 notifications:
     email: false

--- a/Tests/Routing/Generator/Rfc6570GeneratorTest.php
+++ b/Tests/Routing/Generator/Rfc6570GeneratorTest.php
@@ -15,11 +15,12 @@ use Hautelook\TemplatedUriRouter\Routing\Generator\Rfc6570Generator;
 use Symfony\Component\Routing\RequestContext;
 use Symfony\Component\Routing\Route;
 use Symfony\Component\Routing\RouteCollection;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @author Baldur Rensch <baldur.rensch@hautelook.com>
  */
-class Rfc6570GeneratorTest extends \PHPUnit_Framework_TestCase
+class Rfc6570GeneratorTest extends TestCase
 {
     /**
      * @dataProvider getTestPlaceholderData

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,10 @@
     ],
     "require": {
         "php": ">=5.3.0",
-        "symfony/routing": "~2.5|~3.0"
+        "symfony/routing": "~2.5|~3.0|^4.0"
+    },
+    "require-dev": {
+        "phpunit/phpunit": "~4.8"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
         "symfony/routing": "~2.5|~3.0|^4.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "~4.8"
+        "phpunit/phpunit": "^4.8.35|^5.7|^6.5"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Resolves #20

Fixes @stof 's review comments and also makes sure to support newer versions of phpunit that works on PHP 7.1 and 7.2.

cc @baldurrensch @Nyholm 

_Meant to unblock https://github.com/hautelook/TemplatedUriBundle/pull/19, to in turn unblock eZ Platform and others allowing usage on sf4._