### PR TITLE
This library is not a symfony bundle

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,6 @@
         "Hateoas",
         "Router"
     ],
-    "type": "symfony-bundle",
     "license": "MIT",
     "homepage": "http://www.hautelooktech.com/",
     "authors": [


### PR DESCRIPTION
Removing the "symfony-bundle" composer type, this library is not a symfony bundle.

The symfony bundle for this library is https://github.com/hautelook/TemplatedUriBundle