### PR TITLE
Fix rfc6570 incomplient notation of query expansion and continuation

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ $templatedUri      = $templateGenerator->generate('hautelook_demo_route', array(
 This will produce a link similar to:
 
 ```
-/demo{?page,sort%5B%5D*,filter%5B%5D*}
+/demo{?page,sort*,filter*}
 ```
 
 ## Bundle

--- a/Routing/Generator/Rfc6570Generator.php
+++ b/Routing/Generator/Rfc6570Generator.php
@@ -160,7 +160,7 @@ class Rfc6570Generator extends UrlGenerator implements UrlGeneratorInterface, Co
                 if (is_scalar($value)) {
                     $parts[] = urlencode($key);
                 } elseif (is_array($value)) {
-                    $parts[] = urlencode($key) . '%5B%5D*';
+                    $parts[] = urlencode($key) . '*';
                 }
             }
             $url .= '{?' . implode(',', $parts) . '}';

--- a/Tests/Routing/Generator/Rfc6570GeneratorTest.php
+++ b/Tests/Routing/Generator/Rfc6570GeneratorTest.php
@@ -49,7 +49,7 @@ class Rfc6570GeneratorTest extends TestCase
             array('/foo/foobar/{?bar}', array('foo' => 'foobar', 'bar' => 'barbar')),
             array('/foo/foobar/{?bar,paramTwo}', array('foo' => 'foobar', 'bar' => 'barbar', 'paramTwo'=>'paramTwo')),
             array('/foo/foobar/{?bar%3Aencoded}', array('foo' => 'foobar', 'bar:encoded' => 'barbar')),
-            array('/foo/foobar/{?bar%5B%5D*}', array('foo' => 'foobar', 'bar' => array())),
+            array('/foo/foobar/{?bar*}', array('foo' => 'foobar', 'bar' => array())),
             array('/foo/{placeholder}/{?bar}', array('foo' => '{placeholder}', 'bar' => 'barbar')),
         );
     }


### PR DESCRIPTION
This pull request will fix the notation of query parameters, so they will be complient to RFC 6570 section **3.2.8** and **3.2.9**.

The query parameter notation from multiple occurring parameters _(lists)_ has to be `{?list*}` for [Form-Style Query Expansion](https://tools.ietf.org/html/rfc6570#section-3.2.8) and `{&list*}` for [Form-Style Query Continuation](https://tools.ietf.org/html/rfc6570#section-3.2.9).