### PR TITLE
Added Symfony 5 compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     ],
     "require": {
         "php": ">=5.3.0",
-        "symfony/routing": "~2.5|~3.0|^4.0"
+        "symfony/routing": "~2.5|~3.0|^4.0|^5.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^4.8.35|^5.7|^6.5"


### PR DESCRIPTION
Looks like this is a low hanging fruit because there are not any BC breaks making this package incompatible with SF5. At least unit tests are passing. I'd be glad if you can merge it as soon as possible since we need this package in order to migrate ezsystems/ezplatform to Symfony 5.