### PR TITLE
Added Symfony5 compatibility

### DIFF
--- a/Routing/Generator/BcUrlGenerator.php
+++ b/Routing/Generator/BcUrlGenerator.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Hautelook\TemplatedUriRouter\Routing\Generator;
+
+use Symfony\Component\HttpKernel\Kernel;
+
+if (Kernel::MAJOR_VERSION < 5) {
+    abstract class BcUrlGenerator extends \Symfony\Component\Routing\Generator\UrlGenerator
+    {
+    }
+} else {
+    abstract class BcUrlGenerator extends \Symfony\Component\Routing\Generator\CompiledUrlGenerator
+    {
+    }
+}

--- a/Routing/Generator/Rfc6570Generator.php
+++ b/Routing/Generator/Rfc6570Generator.php
@@ -13,7 +13,6 @@ namespace Hautelook\TemplatedUriRouter\Routing\Generator;
 
 use Symfony\Component\Routing\Exception\InvalidParameterException;
 use Symfony\Component\Routing\Exception\MissingMandatoryParametersException;
-use Symfony\Component\Routing\Generator\UrlGenerator;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Symfony\Component\Routing\Generator\ConfigurableRequirementsInterface;
 
@@ -26,7 +25,7 @@ use Symfony\Component\Routing\Generator\ConfigurableRequirementsInterface;
  *
  * @api
  */
-class Rfc6570Generator extends UrlGenerator implements UrlGeneratorInterface, ConfigurableRequirementsInterface
+class Rfc6570Generator extends BcUrlGenerator implements UrlGeneratorInterface, ConfigurableRequirementsInterface
 {
     /**
      * @throws MissingMandatoryParametersException When some parameters are missing that mandatory for the route

--- a/Tests/Routing/Generator/Rfc6570GeneratorTest.php
+++ b/Tests/Routing/Generator/Rfc6570GeneratorTest.php
@@ -55,10 +55,11 @@ class Rfc6570GeneratorTest extends TestCase
         $this->assertEquals('/foo/{placeholder}/{?bar}', $generator->generate('foo', array('foo' => '{placeholder}', 'bar' => 'barbar')));
     }
 
+    /**
+     * @expectedException \Symfony\Component\Routing\Exception\InvalidParameterException
+     */
     public function testStrictParameters()
     {
-        $this->expectException('\Symfony\Component\Routing\Exception\InvalidParameterException');
-
         $routes = $this->getRoutes(true);
 
         $router = new Rfc6570Generator($routes, new RequestContext());

--- a/Tests/Routing/Generator/Rfc6570GeneratorTest.php
+++ b/Tests/Routing/Generator/Rfc6570GeneratorTest.php
@@ -12,6 +12,7 @@
 namespace Hautelook\TemplatedUriRouter\Tests\Routing\Generator;
 
 use Hautelook\TemplatedUriRouter\Routing\Generator\Rfc6570Generator;
+use Symfony\Component\HttpKernel\Kernel;
 use Symfony\Component\Routing\RequestContext;
 use Symfony\Component\Routing\Route;
 use Symfony\Component\Routing\RouteCollection;
@@ -27,16 +28,7 @@ class Rfc6570GeneratorTest extends TestCase
      */
     public function testPlaceholder($expected, $parameters)
     {
-        $routes = new RouteCollection();
-
-        $routes->add('foo', new Route(
-            '/foo/{foo}/',
-            array(
-                'foo'    => '123',
-            ),
-            array(
-            )
-        ));
+        $routes = $this->getRoutes(false);
 
         $router = new Rfc6570Generator($routes, new RequestContext());
 
@@ -56,39 +48,18 @@ class Rfc6570GeneratorTest extends TestCase
 
     public function testPlaceholderInStrictParameter()
     {
-        $routes = new RouteCollection();
-
-        $routes->add('foo', new Route(
-            '/foo/{foo}/',
-            array(
-                'foo' => '123',
-            ),
-            array(
-                'foo' => '\d+',
-            )
-        ));
+        $routes = $this->getRoutes(true);
 
         $generator = new Rfc6570Generator($routes, new RequestContext());
 
         $this->assertEquals('/foo/{placeholder}/{?bar}', $generator->generate('foo', array('foo' => '{placeholder}', 'bar' => 'barbar')));
     }
 
-    /**
-     * @expectedException \Symfony\Component\Routing\Exception\InvalidParameterException
-     */
     public function testStrictParameters()
     {
-        $routes = new RouteCollection();
+        $this->expectException('\Symfony\Component\Routing\Exception\InvalidParameterException');
 
-        $routes->add('foo', new Route(
-            '/foo/{foo}/',
-            array(
-                'foo' => '123',
-            ),
-            array(
-                'foo' => '\d+',
-            )
-        ));
+        $routes = $this->getRoutes(true);
 
         $router = new Rfc6570Generator($routes, new RequestContext());
 
@@ -97,21 +68,50 @@ class Rfc6570GeneratorTest extends TestCase
 
     public function testLooseParameters()
     {
-        $routes = new RouteCollection();
-
-        $routes->add('foo', new Route(
-            '/foo/{foo}/',
-            array(
-                'foo' => '123',
-            ),
-            array(
-                'foo' => '\d+',
-            )
-        ));
+        $routes = $this->getRoutes(true);
 
         $router = new Rfc6570Generator($routes, new RequestContext());
         $router->setStrictRequirements(null);
 
         $this->assertEquals('/foo/foobar/{?bar}', $router->generate('foo', array('foo' => 'foobar', 'bar' => 'barbar')));
+    }
+
+    /**
+     * @param bool $isParamRequired
+     *
+     * @return \Symfony\Component\Routing\RouteCollection
+     */
+    protected function getRoutes($isParamRequired = true)
+    {
+        $regexp = $isParamRequired ? '\d+' : '.*';
+
+        if (Kernel::MAJOR_VERSION < 5) {
+            $routes = new RouteCollection();
+
+            $routes->add('foo', new Route(
+                '/foo/{foo}/',
+                array(
+                    'foo' => '123',
+                ),
+                array($regexp)
+            ));
+        } else {
+            $routes = array(
+                'foo' => array(
+                    array('foo'),
+                    array('foo' => '123'),
+                    array(array('text', '/foo/{foo}/')),
+                    array(
+                        array('text', '/'),
+                        array('variable', '/', $regexp, 'foo', true),
+                        array('text', '/foo'),
+                    ),
+                    array(),
+                    array(),
+                ),
+            );
+        }
+
+        return $routes;
     }
 }

--- a/Tests/Routing/Generator/Rfc6570GeneratorTest.php
+++ b/Tests/Routing/Generator/Rfc6570GeneratorTest.php
@@ -94,7 +94,7 @@ class Rfc6570GeneratorTest extends TestCase
                 array(
                     'foo' => '123',
                 ),
-                array($regexp)
+                $isParamRequired ? array('foo' => $regexp) : array()
             ));
         } else {
             $routes = array(

--- a/composer.json
+++ b/composer.json
@@ -21,8 +21,8 @@
     ],
     "require": {
         "php": ">=5.3.0",
-        "symfony/routing": "~2.5|~3.0|^4.0",
-        "symfony/http-kernel": "~2.5|~3.0|^4.0"
+        "symfony/routing": "~2.5|~3.0|^4.0|^5.0",
+        "symfony/http-kernel": "~2.5|~3.0|^4.0|^5.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^4.8.35"

--- a/composer.json
+++ b/composer.json
@@ -21,11 +21,11 @@
     ],
     "require": {
         "php": ">=5.3.0",
-        "symfony/routing": "~2.5|~3.0|^4.0|^5.0",
-        "symfony/http-kernel": "~2.5|~3.0|^4.0|^5.0"
+        "symfony/routing": "~2.5|~3.0|^4.0",
+        "symfony/http-kernel": "~2.5|~3.0|^4.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^4.8.35|^5.7|^6.5"
+        "phpunit/phpunit": "^4.8.35"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,8 @@
     ],
     "require": {
         "php": ">=5.3.0",
-        "symfony/routing": "~2.5|~3.0|^4.0|^5.0"
+        "symfony/routing": "~2.5|~3.0|^4.0|^5.0",
+        "symfony/http-kernel": "~2.5|~3.0|^4.0|^5.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^4.8.35|^5.7|^6.5"


### PR DESCRIPTION
I'm not an expert on `symfony/routing` but it looks like with Symfony 5 they started using `CompiledUrlGenerator` by default. This is why we need `Rfc6570Generator` to extend `CompiledUrlGenerator` on Symfony 5. 

I've also aligned tests to work properly on Symfony 5.