### PR TITLE
Better detection for symfony 5 router

### DIFF
--- a/Routing/Generator/BcUrlGenerator.php
+++ b/Routing/Generator/BcUrlGenerator.php
@@ -3,13 +3,15 @@
 namespace Hautelook\TemplatedUriRouter\Routing\Generator;
 
 use Symfony\Component\HttpKernel\Kernel;
+use Symfony\Component\Routing\Generator\CompiledUrlGenerator;
+use Symfony\Component\Routing\Generator\UrlGenerator;
 
-if (Kernel::MAJOR_VERSION < 5) {
-    abstract class BcUrlGenerator extends \Symfony\Component\Routing\Generator\UrlGenerator
+if (!class_exists('Symfony\Component\Routing\Generator\CompiledUrlGenerator')) {
+    abstract class BcUrlGenerator extends UrlGenerator
     {
     }
 } else {
-    abstract class BcUrlGenerator extends \Symfony\Component\Routing\Generator\CompiledUrlGenerator
+    abstract class BcUrlGenerator extends CompiledUrlGenerator
     {
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -21,8 +21,7 @@
     ],
     "require": {
         "php": ">=5.3.0",
-        "symfony/routing": "~2.5|~3.0|^4.0|^5.0",
-        "symfony/http-kernel": "~2.5|~3.0|^4.0|^5.0"
+        "symfony/routing": "~2.5|~3.0|^4.0|^5.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^4.8.35|^5.7|^6.5"


### PR DESCRIPTION
Do not rely on HttpKernel to understand if we have a compiled router available

This addresses https://github.com/hautelook/TemplatedUriRouter/pull/29#discussion_r400806226

@stof  do you mind having a look at this?